### PR TITLE
删除hash监听，优化切换速度

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -121,11 +121,11 @@
       id:category_name,
     })
     // 监听URL中hash的变化，如果发现换了一个MD文件，那么刷新页面，解决整个网站使用一个gitalk评论issues的问题。
-    window.onhashchange = function(event){
-        if(event.newURL.split('?')[0] !== event.oldURL.split('?')[0]){
-          location.reload()
-        }
-    }
+    // window.onhashchange = function(event){
+    //     if(event.newURL.split('?')[0] !== event.oldURL.split('?')[0]){
+    //       location.reload()
+    //     }
+    // }
   </script>
 
 <!-- 不蒜子-访问量统计 -->


### PR DESCRIPTION
// 监听URL中hash的变化，如果发现换了一个MD文件，那么刷新页面，解决整个网站使用一个gitalk评论issues的问题。
    // window.onhashchange = function(event){
    //     if(event.newURL.split('?')[0] !== event.oldURL.split('?')[0]){
    //       location.reload()
    //     }
    // }